### PR TITLE
ADAPT-48 improve build and deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ node_modules
 frontend/dist
 backend/nbactions.xml
 templates
-
+.env
+/db

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,46 +3,24 @@ addons:
     packages:
       - sshpass
 
-matrix:
-  include:
-    - language: java
-      if: branch IN (master)
-      sudo: required
-      services:
-        - docker
-      before_install:
-        - cd backend
-      install:
-        - mvn clean install
-        - docker build -t backend .
-        - docker save backend > backend.tar
-      after_success:
-        - export SSHPASS=$DEPLOY_PASS
-        - sshpass -e scp -P $DEPLOY_PORT -o StrictHostKeyChecking=no $TRAVIS_BUILD_DIR/backend/backend.tar $DEPLOY_USER@$DEPLOY_HOST:~/app/backend.tar
-        - sshpass -e ssh -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST -p $DEPLOY_PORT 'docker load -i ~/app/backend.tar && rm ~/app/backend.tar'
+services:
+  - docker
 
-    - language: node_js
-      if: branch IN (master)
-      sudo: required
-      node_js:
-        - "lts/*"
-      cache: yarn
-      services:
-        - docker
-      before_install:
-        - cd frontend
-      script:
-        - yarn build
-        - docker build -t frontend .
-        - docker save frontend > frontend.tar
-      after_success:
-        - export SSHPASS=$DEPLOY_PASS
-        - sshpass -e scp -P $DEPLOY_PORT -o StrictHostKeyChecking=no $TRAVIS_BUILD_DIR/frontend/frontend.tar $DEPLOY_USER@$DEPLOY_HOST:~/app/frontend.tar
-        - sshpass -e ssh -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST -p $DEPLOY_PORT 'docker load -i ~/app/frontend.tar && rm ~/app/frontend.tar'
+sudo: required
 
-    - language: docker-compose
-      if: branch IN (master)
-      sudo: false
-      script:
-        - export SSHPASS=$DEPLOY_PASS
-        - sshpass -e ssh -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST -p $DEPLOY_PORT 'cd ~/app && docker-compose down && docker-compose up -d'
+language: generic
+
+if: branch = master OR env(ADAPT_BUILD_MODE) = test
+
+before_install:
+  - test "$ADAPT_BUILD_MODE" = test || export ADAPT_BUILD_MODE=prod
+  - export SSHPASS=$DEPLOY_PASS
+
+install:
+  - docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.$ADAPT_BUILD_MODE.yml build
+
+after_success:
+  - docker save adapt-backend adapt-frontend | sshpass -e ssh -p $DEPLOY_PORT -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST docker load
+  - sshpass -e scp -P $DEPLOY_PORT -o StrictHostKeyChecking=no docker-compose.yml $DEPLOY_USER@$DEPLOY_HOST:~/adapt-$ADAPT_BUILD_MODE
+  - sshpass -e scp -P $DEPLOY_PORT -o StrictHostKeyChecking=no docker-compose.$ADAPT_BUILD_MODE.yml $DEPLOY_USER@$DEPLOY_HOST:~/adapt-$ADAPT_BUILD_MODE/docker-compose.override.yml
+  - sshpass -e ssh -p $DEPLOY_PORT -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST "cd adapt-$ADAPT_BUILD_MODE && docker-compose down && docker-compose up -d"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,39 @@
-FROM anapsix/alpine-java
+FROM maven:3-jdk-8-alpine AS builder
 
-ENV APP_DIR="/usr/share/adapt"
-ENV JAR="$APP_DIR/adaptation-project-2.0-jar-with-dependencies.jar"
-ENV SETTINGS_DIR="$APP_DIR/classes"
-ENV TEMPLATES_DIR="/usr/share/templates"
+ARG ADAPT_JDBC_URL
+ARG ADAPT_JDBC_USER
+ARG ADAPT_JDBC_PASSWORD
 
-ADD target /usr/share/adapt
+ARG ADAPT_OAUTH_URL
+ARG ADAPT_OAUTH_CLIENT_ID
+ARG ADAPT_OAUTH_CLIENT_SECRET
 
-CMD ["sh", "-c", "exec java -DsettingsDir=$SETTINGS_DIR -DtemplatesDir=$TEMPLATES_DIR -jar $JAR"]
+ARG ADAPT_SMTP_HOST
+ARG ADAPT_SMTP_USER
+ARG ADAPT_SMTP_PASSWORD
+
+ARG ADAPT_EMAIL1
+ARG ADAPT_EMAIL2
+
+
+COPY src /usr/src/adapt/src
+COPY pom.xml /usr/src/adapt
+COPY checkstyle.xml /usr/src/adapt
+
+WORKDIR /usr/src/adapt
+
+RUN mvn clean install
+
+
+
+FROM boxfuse/flyway:5-alpine
+
+COPY --from=builder /usr/src/adapt/target /usr/share/adapt
+COPY src/main/resources/db/migration /flyway/sql
+COPY run.sh /usr/share/adapt
+
+RUN chmod +x /usr/share/adapt/run.sh
+
+WORKDIR /usr/share/adapt
+
+ENTRYPOINT /usr/share/adapt/run.sh

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.hh.school</groupId>
     <artifactId>adaptation-project</artifactId>
@@ -225,16 +227,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                         <phase>package</phase>
                         <configuration>
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>
                             </descriptorRefs>
+                            <appendAssemblyId>false</appendAssemblyId>
                             <archive>
                                 <manifest>
                                     <mainClass>ru.hh.school.adaptation.AdaptationMain</mainClass>

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+flyway migrate -configFiles=classes/flyway.conf
+exec java -DsettingsDir=classes -DtemplatesDir=templates -jar *.jar

--- a/backend/src/main/resources/configs/flyway.conf
+++ b/backend/src/main/resources/configs/flyway.conf
@@ -1,0 +1,3 @@
+flyway.url=${jdbc.url}
+flyway.user=${jdbc.user}
+flyway.password=${jdbc.password}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,31 @@
+version: "2.1"
+
+services:
+  postgres:
+    ports:
+      - 5432:5432
+    volumes:
+      - ./db:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ./backend
+      args:
+        ADAPT_JDBC_URL: ${ADAPT_JDBC_URL}
+        ADAPT_JDBC_USER: ${ADAPT_JDBC_USER}
+        ADAPT_JDBC_PASSWORD: ${ADAPT_JDBC_PASSWORD}
+        ADAPT_OAUTH_URL: ${ADAPT_OAUTH_URL}
+        ADAPT_OAUTH_CLIENT_ID: ${ADAPT_OAUTH_CLIENT_ID}
+        ADAPT_OAUTH_CLIENT_SECRET: ${ADAPT_OAUTH_CLIENT_SECRET}
+        ADAPT_SMTP_HOST: ${ADAPT_SMTP_HOST}
+        ADAPT_SMTP_USER: ${ADAPT_SMTP_USER}
+        ADAPT_SMTP_PASSWORD: ${ADAPT_SMTP_PASSWORD}
+        ADAPT_EMAIL1: ${ADAPT_EMAIL1}
+        ADAPT_EMAIL2: ${ADAPT_EMAIL2}
+    image: adapt-backend:dev
+
+  frontend:
+    build: ./frontend
+    image: adapt-frontend:dev
+    ports:
+      - 3000:80

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,33 @@
+version: "2.1"
+
+services:
+  postgres:
+    ports:
+      - 5432:5432
+    volumes:
+      - ./db:/var/lib/postgresql/data
+    networks:
+      default:
+        aliases:
+          - postgres
+      shared:
+        aliases:
+          - postgres-prod
+
+  backend:
+    image: adapt-backend:prod
+
+  frontend:
+    image: adapt-frontend:prod
+    networks:
+      default:
+        aliases:
+          - frontend
+      shared:
+        aliases:
+          - frontend-prod
+
+networks:
+  shared:
+    external:
+      name: adapt-shared

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,29 @@
+version: "2.1"
+
+services:
+  postgres:
+    ports:
+      - 5433:5432
+    volumes:
+      - ./db-scripts:/docker-entrypoint-initdb.d/
+    networks:
+      - default
+      - shared
+
+  backend:
+    image: adapt-backend:test
+
+  frontend:
+    image: adapt-frontend:test
+    networks:
+      default:
+        aliases:
+          - frontend
+      shared:
+        aliases:
+          - frontend-test
+
+networks:
+  shared:
+    external:
+      name: adapt-shared

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,26 @@
-version: '2'
+version: "2.1"
+
 services:
   postgres:
     image: postgres
     restart: always
-    ports:
-      - 5432:5432
-    volumes:
-      - ~/db/adapt:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 30s
+      timeout: 30s
+      retries: 3
     environment:
       POSTGRES_DB: adapt
 
   backend:
-    image: backend
+    restart: always
     volumes:
-      - $PWD/templates:/usr/share/templates
+      - ./templates:/usr/share/adapt/templates
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   frontend:
-    image: frontend
-    ports:
-      - 3000:80
+    restart: always
     depends_on:
       - backend

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -5,11 +5,6 @@ events {
 http {
     include mime.types;
 
-    map $sent_http_set_cookie $set_session_cookie {
-        default "";
-        ~(.*)JSESSIONID=(.*) $1adaptation_session=$2;
-    }
-
     server {
         listen 80;
 
@@ -20,10 +15,8 @@ http {
         }
 
         location /api/ {
-            add_header Set-Cookie $set_session_cookie;
-            proxy_set_header Cookie JSESSIONID=$cookie_adaptation_session;
             proxy_pass http://backend:9999/;
-            proxy_redirect http://backend:9999/ https://$http_x_real_host/;
+            proxy_redirect http://backend:9999/ http://$http_x_real_host/;
         }
     }
 }


### PR DESCRIPTION
https://jira.hh.ru/browse/ADAPT-48

Ещё одно улучшение окружения для сборки и деплоя адаптации. 
Максимально подготовлено к тому, чтобы накатывать тестовое приложение на виртуалку.

* Джава билдится внутри докера, как и фронтенд.
* Тестовое приложение накатывается трэвисом через магию докер-компоуз.
* При накатке база копируется с продовского приложения. *
* Снова поддерживаются флайвей-миграции. Флайвей запускается перед стартом бэкенда, как прода, так и теста.
* Теперь приложение можно стартануть у себя на локальной машине просто выполнив команду docker-compose up (правда без копии продовской базы). **

\* _сам скрипт копирования базы находится на виртуалке (чтобы не копировать каждый раз и не выставлять права на исполнение, а то гит их не поддерживает)_
\** _экспериментальная фича_