### PR TITLE
ADAPT-66 mock email when copy db from prod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,17 @@ before_install:
   - test "$ADAPT_BUILD_MODE" = prod || export ADAPT_SMTP_HOST=$ADAPT_TEST_SMTP_HOST
   - test "$ADAPT_BUILD_MODE" = prod || export ADAPT_SMTP_USER=$ADAPT_TEST_SMTP_USER
   - test "$ADAPT_BUILD_MODE" = prod || export ADAPT_SMTP_PASSWORD=$ADAPT_TEST_SMTP_PASSWORD
+  - test "$ADAPT_BUILD_MODE" = prod || echo ADAPT_MOCK_EMAIL=$ADAPT_MOCK_EMAIL >> .env
   - export SSHPASS=$DEPLOY_PASS
+  - export SSH_CMD="sshpass -e ssh -p $DEPLOY_PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
 install:
   - docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.$ADAPT_BUILD_MODE.yml build
 
 after_success:
-  - docker save adapt-backend adapt-frontend | sshpass -e ssh -p $DEPLOY_PORT -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST docker load
-  - sshpass -e scp -P $DEPLOY_PORT -o StrictHostKeyChecking=no docker-compose.yml $DEPLOY_USER@$DEPLOY_HOST:~/adapt-$ADAPT_BUILD_MODE
-  - sshpass -e scp -P $DEPLOY_PORT -o StrictHostKeyChecking=no docker-compose.$ADAPT_BUILD_MODE.yml $DEPLOY_USER@$DEPLOY_HOST:~/adapt-$ADAPT_BUILD_MODE/docker-compose.override.yml
-  - sshpass -e ssh -p $DEPLOY_PORT -o StrictHostKeyChecking=no $DEPLOY_USER@$DEPLOY_HOST "cd adapt-$ADAPT_BUILD_MODE && docker-compose down && docker-compose up -d"
+  - docker save adapt-backend adapt-frontend | $SSH_CMD $DEPLOY_USER@$DEPLOY_HOST docker load
+  - rsync -e "$SSH_CMD" docker-compose.yml $DEPLOY_USER@$DEPLOY_HOST:~/adapt-$ADAPT_BUILD_MODE/
+  - rsync -e "$SSH_CMD" docker-compose.$ADAPT_BUILD_MODE.yml $DEPLOY_USER@$DEPLOY_HOST:~/adapt-$ADAPT_BUILD_MODE/docker-compose.override.yml
+  - rsync -e "$SSH_CMD" .env $DEPLOY_USER@$DEPLOY_HOST:~/adapt-$ADAPT_BUILD_MODE/
+  - test "$ADAPT_BUILD_MODE" = prod || rsync -e "$SSH_CMD" --chmod=+x copy-db.sh $DEPLOY_USER@$DEPLOY_HOST:~/adapt-test/db-scripts/
+  - $SSH_CMD $DEPLOY_USER@$DEPLOY_HOST "cd adapt-$ADAPT_BUILD_MODE && docker-compose down && docker-compose up -d"

--- a/copy-db.sh
+++ b/copy-db.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+pg_dump -h postgres-prod -F c $POSTGRES_DB | pg_restore -c -d $POSTGRES_DB
+psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<EOF
+    UPDATE personal_info SET email = '$ADAPT_MOCK_EMAIL';
+EOF
+
+exit 0

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,8 @@ services:
     networks:
       - default
       - shared
+    environment:
+      ADAPT_MOCK_EMAIL: ${ADAPT_MOCK_EMAIL}
 
   backend:
     image: adapt-backend:test


### PR DESCRIPTION
При копировании продовской базы на стенд все email адреса заменяются на значение переменной `ADAPT_MOCK_EMAIL`. Скрипт копирования базы теперь находится под контролем версий. Деплой в конфиге трэвиса теперь выполняется через `rsync`.